### PR TITLE
Fix critical security issues from architectural review

### DIFF
--- a/crates/matching-engine/src/error.rs
+++ b/crates/matching-engine/src/error.rs
@@ -1,6 +1,13 @@
 use thiserror::Error;
 use rust_decimal::Decimal;
 
+/// Maximum acceptable oracle confidence interval (2% = 0.02)
+/// If confidence exceeds this, the oracle price is too uncertain for safe matching
+pub const MAX_CONFIDENCE_THRESHOLD: &str = "0.02";
+
+/// Maximum number of solver quotes per auction to prevent DoS
+pub const MAX_QUOTES_PER_AUCTION: usize = 100;
+
 #[derive(Debug, Error)]
 pub enum MatchingError {
     #[error("intent not found: {0}")]
@@ -28,5 +35,29 @@ pub enum MatchingError {
     PriceBelowLimit {
         oracle_price: Decimal,
         limit_price: Decimal,
+    },
+
+    #[error("oracle price too uncertain: confidence={confidence}, threshold={threshold}")]
+    OraclePriceUncertain {
+        confidence: Decimal,
+        threshold: Decimal,
+    },
+
+    #[error("intent expired: expires_at={expires_at}, current_time={current_time}")]
+    IntentExpired {
+        expires_at: u64,
+        current_time: u64,
+    },
+
+    #[error("too many solver quotes: count={count}, max={max}")]
+    TooManyQuotes {
+        count: usize,
+        max: usize,
+    },
+
+    #[error("nonce already used: user={user}, nonce={nonce}")]
+    NonceAlreadyUsed {
+        user: String,
+        nonce: u64,
     },
 }


### PR DESCRIPTION
CRITICAL FIX: Remove oracle dependency from intent matching (5.1)
- Implement midpoint pricing: execution price derived from intent limits
- Oracle now only used as optional sanity check (10% max deviation)
- Eliminates oracle manipulation attack surface
- Both parties get price improvement (surplus split fairly)

HIGH FIX: Settlement state machine guards (1.3)
- Add can_transition_to() method for valid state transitions
- Prevent invalid state manipulation attacks
- All state changes now validated before execution

HIGH FIX: Escrow/settlement race condition (5.6)
- Add expiration check in release function
- Prevents race between user refund and settlement release
- Expired escrows cannot be released, only refunded

MEDIUM FIX: Minimum slashing threshold (1.7)
- Add MIN_SLASH_AMOUNT constant (1 ATOM)
- Prevents dust attacks and slashing gaming
- Protects against low-bond exploitation

Additional security improvements:
- Oracle confidence threshold validation (2% max uncertainty)
- Intent expiration enforcement in batch auctions
- Solver quote bounds checking (max 100 quotes)
- Nonce tracking for replay protection
- CEX inventory rollback capability for settlement failures