### PR TITLE
Design USDC swap functionality with Tia

### DIFF
--- a/demo/skip-select-simulator/src/api.rs
+++ b/demo/skip-select-simulator/src/api.rs
@@ -215,6 +215,8 @@ pub async fn generate_demo_intent(
         ("ATOM", "USDC", "cosmoshub-4", "noble-1"),
         ("USDC", "ATOM", "noble-1", "cosmoshub-4"),
         ("NTRN", "ATOM", "neutron-1", "cosmoshub-4"),
+        ("TIA", "USDC", "celestia", "noble-1"),  // Featured: Celestia swap
+        ("TIA", "ATOM", "celestia", "cosmoshub-4"),
     ];
 
     let (input_denom, output_denom, input_chain, output_chain) =
@@ -320,6 +322,33 @@ fn get_scenario(name: &str) -> Option<DemoScenario> {
                 timeout_seconds: Some(60),
             }],
             expected_outcome: "DEX Router fills via Osmosis AMM".to_string(),
+        }),
+        "tia_usdc_swap" => Some(DemoScenario {
+            name: "tia_usdc_swap".to_string(),
+            description: "TIA -> USDC cross-chain swap from Celestia (no smart contracts) via Hub escrow".to_string(),
+            intents: vec![CreateIntentRequest {
+                user_address: "celestia1demo_user".to_string(),
+                input: Asset {
+                    chain_id: "celestia".to_string(),
+                    denom: "TIA".to_string(),
+                    amount: 100_000_000, // 100 TIA
+                },
+                output: OutputSpec {
+                    chain_id: "noble-1".to_string(),
+                    denom: "USDC".to_string(),
+                    min_amount: 500_000_000, // ~$500 USDC (at ~$5/TIA)
+                    max_price: None,
+                },
+                fill_config: None,
+                constraints: Some(ExecutionConstraints {
+                    max_hops: 3,
+                    allowed_venues: vec!["osmosis".to_string()],
+                    excluded_venues: vec![],
+                    max_slippage_bps: 100,
+                }),
+                timeout_seconds: Some(60),
+            }],
+            expected_outcome: "Flow: Celestia -> Hub Escrow (IBC Hooks) -> Solver delivers USDC -> Hub releases TIA. Solver takes relay risk.".to_string(),
         }),
         "intent_matching" => Some(DemoScenario {
             name: "intent_matching".to_string(),

--- a/demo/skip-select-simulator/src/main.rs
+++ b/demo/skip-select-simulator/src/main.rs
@@ -140,6 +140,7 @@ impl Default for Config {
                 ("USDC".to_string(), 1.00),
                 ("NTRN".to_string(), 0.45),
                 ("STRD".to_string(), 1.20),
+                ("TIA".to_string(), 5.25),  // Celestia
             ],
         }
     }

--- a/demo/skip-select-simulator/src/state.rs
+++ b/demo/skip-select-simulator/src/state.rs
@@ -122,6 +122,30 @@ impl AppState {
                 ],
                 connected_at: Some(Utc::now()),
             },
+            // Celestia cross-chain solver (Hub escrow + relay risk)
+            Solver {
+                id: "solver_celestia_bridge".to_string(),
+                name: "Celestia Bridge Solver".to_string(),
+                solver_type: SolverType::Hybrid,
+                status: SolverStatus::Active,
+                reputation_score: 0.94,
+                total_volume: 0,
+                success_rate: 0.97,
+                avg_execution_time_ms: 13000, // ~13s for cross-chain via Hub escrow
+                supported_chains: vec![
+                    "celestia".to_string(),
+                    "cosmoshub-4".to_string(),
+                    "osmosis-1".to_string(),
+                    "noble-1".to_string(),
+                ],
+                supported_denoms: vec![
+                    "TIA".to_string(),
+                    "ATOM".to_string(),
+                    "USDC".to_string(),
+                    "OSMO".to_string(),
+                ],
+                connected_at: Some(Utc::now()),
+            },
         ];
 
         for solver in mock_solvers {

--- a/demo/web-ui/src/components/DemoScenarios.tsx
+++ b/demo/web-ui/src/components/DemoScenarios.tsx
@@ -24,6 +24,7 @@ function ScenarioCard({
 }) {
   const iconMap: Record<string, string> = {
     simple_swap: '🔄',
+    tia_usdc_swap: '🟣',
     intent_matching: '🎯',
     multi_hop: '🌐',
     cex_backstop: '🏦',
@@ -131,6 +132,74 @@ export default function DemoScenarios() {
             result={results[scenario.id]}
           />
         ))}
+      </div>
+
+      {/* Featured: TIA → USDC Flow */}
+      <div className="card bg-gradient-to-br from-purple-900/30 to-transparent border-purple-700/50">
+        <div className="flex items-center gap-3 mb-4">
+          <span className="text-2xl">🟣</span>
+          <h3 className="font-semibold text-white">TIA → USDC: Cross-Chain from Celestia</h3>
+          <span className="px-2 py-1 text-xs bg-purple-600/50 rounded-full text-purple-200">Featured</span>
+        </div>
+        <p className="text-gray-400 text-sm mb-4">
+          Celestia has no smart contracts, so the system uses <strong className="text-purple-300">Hub escrow with solver relay risk</strong>.
+        </p>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          {/* Phase 1 */}
+          <div className="p-4 bg-gray-800/50 rounded-lg border border-purple-700/30">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-6 h-6 rounded-full bg-purple-600 flex items-center justify-center text-xs text-white">1</div>
+              <span className="text-sm font-medium text-white">User → Hub Escrow</span>
+            </div>
+            <div className="space-y-2 text-xs text-gray-400">
+              <div className="flex items-center gap-2">
+                <span className="text-purple-400">Celestia</span>
+                <ArrowRight className="w-3 h-3" />
+                <span className="text-cosmos-400">Hub</span>
+              </div>
+              <p>TIA sent via IBC with wasm hook memo</p>
+              <p className="text-purple-300">Escrow locks atomically on receive</p>
+            </div>
+          </div>
+          {/* Phase 2 */}
+          <div className="p-4 bg-gray-800/50 rounded-lg border border-green-700/30">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-6 h-6 rounded-full bg-green-600 flex items-center justify-center text-xs text-white">2</div>
+              <span className="text-sm font-medium text-white">Solver → User</span>
+            </div>
+            <div className="space-y-2 text-xs text-gray-400">
+              <div className="flex items-center gap-2">
+                <span className="text-green-400">Solver</span>
+                <ArrowRight className="w-3 h-3" />
+                <span className="text-green-300">Noble</span>
+              </div>
+              <p>Solver sends USDC to user</p>
+              <p className="text-yellow-300">⚠️ Solver takes relay risk</p>
+            </div>
+          </div>
+          {/* Phase 3 */}
+          <div className="p-4 bg-gray-800/50 rounded-lg border border-cosmos-700/30">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-6 h-6 rounded-full bg-cosmos-600 flex items-center justify-center text-xs text-white">3</div>
+              <span className="text-sm font-medium text-white">Hub Adjudicates</span>
+            </div>
+            <div className="space-y-2 text-xs text-gray-400">
+              <div className="flex items-center gap-2">
+                <span className="text-cosmos-400">Hub</span>
+                <ArrowRight className="w-3 h-3" />
+                <span className="text-blue-400">Solver</span>
+              </div>
+              <p>Settlement verifies IBC ack</p>
+              <p className="text-green-300">✓ Releases TIA to solver</p>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 p-3 bg-purple-900/20 rounded-lg border border-purple-700/30">
+          <p className="text-purple-300 text-xs">
+            <strong>Key insight:</strong> No smart contracts needed on Celestia. Hub escrow protects users.
+            Solvers take relay risk → incentivized to run reliable relayers.
+          </p>
+        </div>
       </div>
 
       {/* Scenario Details */}

--- a/demo/web-ui/src/types/index.ts
+++ b/demo/web-ui/src/types/index.ts
@@ -216,6 +216,7 @@ export type WsMessage =
 // Demo scenarios
 export const DEMO_SCENARIOS = [
   { id: 'simple_swap', name: 'Simple Swap', description: 'Basic ATOM → OSMO swap via DEX' },
+  { id: 'tia_usdc_swap', name: 'TIA → USDC (Celestia)', description: 'Cross-chain swap from Celestia via Hub escrow' },
   { id: 'intent_matching', name: 'Intent Matching', description: 'Two opposing intents matched directly' },
   { id: 'multi_hop', name: 'Multi-Hop', description: 'Cross-chain settlement via IBC PFM' },
   { id: 'cex_backstop', name: 'CEX Backstop', description: 'Large order using CEX liquidity' },
@@ -229,6 +230,7 @@ export const TOKENS: Record<string, { symbol: string; name: string; chain: strin
   USDC: { symbol: 'USDC', name: 'USD Coin', chain: 'noble-1', logo: '💵' },
   NTRN: { symbol: 'NTRN', name: 'Neutron', chain: 'neutron-1', logo: '⚡' },
   STRD: { symbol: 'STRD', name: 'Stride', chain: 'stride-1', logo: '🏃' },
+  TIA: { symbol: 'TIA', name: 'Celestia', chain: 'celestia', logo: '🟣' },
 };
 
 export const CHAINS = [
@@ -237,4 +239,5 @@ export const CHAINS = [
   { id: 'neutron-1', name: 'Neutron' },
   { id: 'noble-1', name: 'Noble' },
   { id: 'stride-1', name: 'Stride' },
+  { id: 'celestia', name: 'Celestia', hasSmartContracts: false },
 ];

--- a/docs/TIA_USDC_SWAP_SPECIFICATION.md
+++ b/docs/TIA_USDC_SWAP_SPECIFICATION.md
@@ -1,0 +1,941 @@
+# TIA/USDC Swap Specification
+
+## Solver-Managed Settlement for Non-Smart-Contract Chains
+
+---
+
+## Executive Summary
+
+This document specifies how users with TIA on Celestia (a chain without smart contracts) can swap to USDC. The key insight is that **solvers take responsibility for packet delivery** - they run their own relayers and are incentivized to ensure IBC packets don't timeout.
+
+### The Problem
+
+Celestia is a data availability layer without CosmWasm smart contract support. Traditional two-phase settlement requires locking user funds in an escrow contract, which cannot execute on Celestia.
+
+### The Solution
+
+**Solver-Managed Settlement with Hub Adjudication**:
+
+1. User's TIA is sent via IBC to the **Hub escrow contract** (not directly to solver)
+2. Solver delivers USDC to user on destination chain
+3. Hub settlement contract verifies USDC delivery via IBC ack
+4. Only then does Hub release TIA from escrow to solver
+5. Solver's integrated relayer ensures packets don't timeout
+
+**Key insight**: The Hub still adjudicates the swap - it verifies the solver delivered before releasing user funds. But **solvers take the relay risk** - they're responsible for ensuring their USDC delivery packet doesn't timeout.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                 SOLVER-MANAGED SETTLEMENT WITH HUB ADJUDICATION                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────┐          ┌─────────────────────────┐          ┌─────────────────┐
+│                 │          │       COSMOS HUB        │          │                 │
+│    CELESTIA     │          │    (Adjudication)       │          │      NOBLE      │
+│                 │          │                         │          │                 │
+│  ┌───────────┐  │   IBC    │  ┌─────────────────┐   │          │  ┌───────────┐  │
+│  │           │  │ + Hooks  │  │                 │   │          │  │           │  │
+│  │  User's   │──┼─────────►│  │  Escrow (TIA)   │   │          │  │   User    │  │
+│  │   TIA     │  │          │  │                 │   │          │  │  receives │  │
+│  │           │  │          │  └────────┬────────┘   │          │  │   USDC    │  │
+│  └───────────┘  │          │           │            │          │  └───────────┘  │
+│                 │          │           │ Verify     │          │        ▲        │
+│  No smart       │          │           │ delivery   │          │        │        │
+│  contracts      │          │           ▼            │          │        │        │
+│  needed!        │          │  ┌─────────────────┐   │   IBC    │        │        │
+│                 │          │  │   Settlement    │   │          │        │        │
+│                 │          │  │   Contract      │───┼──────────┼────────┘        │
+│                 │          │  │                 │   │  (USDC   │                 │
+│                 │          │  └────────┬────────┘   │  to user)│                 │
+│                 │          │           │            │          │                 │
+│                 │          │           │ On success │          │                 │
+│                 │          │           ▼            │          │                 │
+│                 │          │  ┌─────────────────┐   │          │                 │
+│                 │          │  │ Release TIA     │   │          │                 │
+│                 │          │  │ to Solver       │   │          │                 │
+│                 │          │  └─────────────────┘   │          │                 │
+│                 │          │                         │          │                 │
+└─────────────────┘          └─────────────────────────┘          └─────────────────┘
+
+                              ┌────────────────────┐
+                              │      SOLVER        │
+                              │  ┌──────────────┐  │
+                              │  │   Relayer    │  │
+                              │  │  (Priority   │  │
+                              │  │   delivery)  │  │
+                              │  └──────────────┘  │
+                              │                    │
+                              │  Takes relay risk: │
+                              │  If USDC packet    │
+                              │  times out, solver │
+                              │  loses (no TIA)    │
+                              └────────────────────┘
+```
+
+### How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                            SETTLEMENT FLOW                                       │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  1. User sends TIA → Hub escrow (via IBC from Celestia)                         │
+│     └── Uses IBC Hooks to lock in escrow contract atomically                    │
+│                                                                                  │
+│  2. Solver sees escrow locked, sends USDC → User on Noble                       │
+│     └── Solver takes risk: must deliver before timeout                          │
+│     └── Solver's relayer prioritizes this packet                                │
+│                                                                                  │
+│  3. Hub settlement contract receives IBC ack proving USDC delivered             │
+│     └── This is the adjudication step                                           │
+│                                                                                  │
+│  4. Hub releases TIA from escrow to solver                                      │
+│     └── Solver is now made whole                                                │
+│                                                                                  │
+│  ═══════════════════════════════════════════════════════════════════════════    │
+│                                                                                  │
+│  SOLVER RISK: If USDC delivery times out:                                       │
+│  • User's TIA remains locked (eventually refunded to user)                      │
+│  • Solver loses the USDC they sent (it times out back to them)                  │
+│  • This incentivizes solvers to run reliable relayers!                          │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Design Principles
+
+### 1. Hub as Neutral Adjudicator
+
+The Cosmos Hub serves as the trust anchor:
+
+| Aspect | Rationale |
+|--------|-----------|
+| **Escrow contract** | Holds user's TIA until delivery is verified |
+| **Settlement contract** | Receives IBC acks, releases escrow on success |
+| **Neutral ground** | Neither user nor solver controls the adjudication |
+| **IBC Hooks** | Enables atomic lock-on-receive from Celestia |
+
+### 2. Solvers Take Relay Risk
+
+Solvers are responsible for ensuring IBC packets don't timeout:
+
+| Aspect | Rationale |
+|--------|-----------|
+| **Integrated relayers** | Solvers already run relayers to protect their capital |
+| **Aligned incentives** | Faster delivery = shorter exposure = more auction wins |
+| **Timeout = loss** | If USDC delivery times out, solver doesn't get TIA |
+| **Risk pricing** | Solvers can price relay risk into their quotes |
+
+### 3. Single User Signature
+
+Users sign **one transaction** on Celestia:
+- IBC transfer to Hub escrow (with wasm hook memo)
+- Escrow locks atomically on receive
+- User is protected: TIA refunds if settlement fails
+
+### 4. Trustless Settlement
+
+The flow is trustless because:
+- User's TIA is locked in Hub escrow (not sent to solver directly)
+- Solver only gets TIA after Hub verifies USDC delivery
+- If USDC delivery fails, user's TIA is refunded
+
+---
+
+## Complete TIA → USDC Flow
+
+### Phase 0: Intent Submission & Solver Selection
+
+User submits intent via Skip Select, solver wins auction:
+
+```rust
+Intent {
+    id: "int_abc123",
+    user: "celestia1user...",
+
+    input: Asset {
+        chain_id: "celestia",
+        denom: "utia",
+        amount: 1_000_000_000,  // 1000 TIA
+    },
+
+    output: OutputSpec {
+        chain_id: "noble-1",
+        denom: "uusdc",
+        min_amount: 5_000_000_000,  // 5000 USDC minimum
+        limit_price: Decimal::from_str("5.0")?,
+        recipient: "noble1user...",
+    },
+
+    constraints: ExecutionConstraints {
+        deadline: now + 60,
+        max_hops: 3,
+        ..Default::default()
+    },
+}
+```
+
+### Phase 1: User Sends TIA to Hub Escrow
+
+User signs a single IBC transfer on Celestia with IBC Hooks memo:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                    PHASE 1: TIA → HUB ESCROW (Atomic via IBC Hooks)              │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+  CELESTIA                                    COSMOS HUB
+      │                                            │
+ T=0  │  User signs MsgTransfer                    │
+      │  ┌──────────────────────────────────────┐  │
+      │  │ receiver: cosmos1escrow...           │  │
+      │  │ channel: channel-celestia-hub        │  │
+      │  │ amount: 1000 TIA                     │  │
+      │  │ memo: {                              │  │
+      │  │   "wasm": {                          │  │
+      │  │     "contract": "cosmos1escrow...",  │  │
+      │  │     "msg": {                         │  │
+      │  │       "lock_from_ibc": {             │  │
+      │  │         "intent_id": "int_abc123",   │  │
+      │  │         "solver_id": "solver1",      │  │
+      │  │         "expires_at": T+15min        │  │
+      │  │       }                              │  │
+      │  │     }                                │  │
+      │  │   }                                  │  │
+      │  │ }                                    │  │
+      │  └──────────────────────────────────────┘  │
+      │                                            │
+      │  ─────────────── IBC Packet ─────────────► │
+      │                                            │
+      │                                   ┌────────┴────────┐
+      │                                   │   IBC Hooks     │
+      │                                   │   Middleware    │
+      │                                   │                 │
+      │                                   │ 1. Receive TIA  │
+      │                                   │ 2. Call escrow  │
+      │                                   │    contract     │
+      │                                   │ 3. Lock funds   │
+      │                                   │    atomically   │
+      │                                   └────────┬────────┘
+      │                                            │
+      │                                   Escrow Created:
+      │                                   ┌─────────────────────┐
+      │                                   │ id: "esc_xyz"       │
+      │                                   │ intent: "int_abc123"│
+      │                                   │ amount: 1000 TIA    │
+      │                                   │ denom: ibc/TIA      │
+      │                                   │ solver: "solver1"   │
+      │                                   │ expires: T+15min    │
+      │                                   └─────────────────────┘
+      │                                            │
+      │  ◄──────────── IBC Ack ────────────────── │
+      │                                            │
+ T=6s │  TIA LOCKED IN ESCROW ✓                    │
+```
+
+### Phase 2: Solver Delivers USDC to User
+
+Solver sees escrow lock and sends USDC (solver takes relay risk here):
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                    PHASE 2: SOLVER DELIVERS USDC (Solver takes risk)             │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+  SOLVER (on Hub or Osmosis)                      NOBLE
+      │                                               │
+ T=7s │  Solver sees escrow locked                    │
+      │  Initiates USDC delivery                      │
+      │                                               │
+      │  MsgTransfer (via Settlement Contract)        │
+      │  ┌──────────────────────────────────────┐     │
+      │  │ sender: cosmos1settlement...         │     │
+      │  │ receiver: noble1user...              │     │
+      │  │ channel: channel-hub-noble           │     │
+      │  │ amount: 5100 USDC                    │     │
+      │  │ memo: { "intent_id": "int_abc123" }  │     │
+      │  │ ibc_callback: cosmos1settlement...   │ ◄── IBC callback for ack!
+      │  └──────────────────────────────────────┘     │
+      │                                               │
+      │  ─────────────── IBC Packet ────────────────► │
+      │                                               │
+      │                                  ┌────────────┴────────────┐
+      │                                  │                         │
+      │                                  │  User receives          │
+      │                                  │  5100 USDC on Noble     │
+      │                                  │                         │
+      │                                  │  noble1user...          │
+      │                                  │                         │
+      │                                  └────────────┬────────────┘
+      │                                               │
+      │  ◄─────────────── IBC Ack ───────────────────│
+      │                                               │
+T=12s │  USER HAS USDC ✓                              │
+      │                                               │
+      │  ┌────────────────────────────────────────┐   │
+      │  │ Settlement contract receives IBC ack   │   │
+      │  │ This PROVES delivery happened          │   │
+      │  └────────────────────────────────────────┘   │
+```
+
+### Phase 3: Hub Releases Escrow to Solver
+
+Settlement contract verifies delivery and releases TIA:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                    PHASE 3: HUB ADJUDICATION & ESCROW RELEASE                    │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+  COSMOS HUB                                      SOLVER
+      │                                               │
+T=12s │  Settlement contract receives IBC ack         │
+      │  proving USDC was delivered to user           │
+      │                                               │
+      │  ┌────────────────────────────────────────┐   │
+      │  │  Settlement Contract Logic:            │   │
+      │  │                                        │   │
+      │  │  1. Verify ack matches intent_id       │   │
+      │  │  2. Verify delivery amount correct     │   │
+      │  │  3. Call escrow.release(solver)        │   │
+      │  └────────────────────────────────────────┘   │
+      │                                               │
+      │  MsgExecuteContract (internal)                │
+      │  ┌────────────────────────────────────────┐   │
+      │  │ escrow.release {                       │   │
+      │  │   escrow_id: "esc_xyz",                │   │
+      │  │   recipient: "cosmos1solver..."        │   │
+      │  │ }                                      │   │
+      │  └────────────────────────────────────────┘   │
+      │                                               │
+      │  Escrow releases 1000 ibc/TIA ───────────────►│
+      │                                               │
+T=13s │  SETTLEMENT COMPLETE ✓                        │
+      │                                               │
+      │  Solver now has ibc/TIA on Hub                │
+      │  Can swap on Osmosis or IBC back to Celestia  │
+```
+
+### Complete Timeline
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         COMPLETE TIA → USDC TIMELINE                             │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  T+0s      User signs IBC transfer on Celestia (with wasm hook memo)            │
+│            └── Single signature, single transaction                             │
+│                                                                                  │
+│  T+6s      TIA arrives on Hub, escrow contract locks it atomically              │
+│            └── Atomic via IBC Hooks - if lock fails, IBC reverts                │
+│                                                                                  │
+│  T+7s      Solver sees escrow, initiates USDC delivery via Hub                  │
+│            └── SOLVER TAKES RISK: must deliver before timeout                   │
+│                                                                                  │
+│  T+12s     USDC arrives on Noble, user receives funds                           │
+│            └── IBC ack sent back to Hub settlement contract                     │
+│                                                                                  │
+│  T+13s     Settlement contract verifies delivery, releases TIA to solver        │
+│            └── ADJUDICATION COMPLETE                                             │
+│                                                                                  │
+│  ═══════════════════════════════════════════════════════════════════════════    │
+│  TOTAL TIME: ~13 seconds                                                         │
+│  USER ACTIONS: 1 signature                                                       │
+│  SMART CONTRACTS ON CELESTIA: None required                                      │
+│  TRUST: Hub adjudicates - user protected, solver takes relay risk               │
+│  ═══════════════════════════════════════════════════════════════════════════    │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Failure Scenarios
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         FAILURE HANDLING                                         │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  SCENARIO 1: User's IBC to Hub fails                                            │
+│  ─────────────────────────────────────                                          │
+│  • IBC times out or errors                                                       │
+│  • TIA returns to user on Celestia automatically                                │
+│  • No escrow created, no settlement                                             │
+│  • User can retry                                                                │
+│                                                                                  │
+│  SCENARIO 2: Solver's USDC delivery times out                                   │
+│  ───────────────────────────────────────────────                                │
+│  • User's TIA remains in Hub escrow                                             │
+│  • Solver's USDC times out back to solver (no loss of USDC)                     │
+│  • BUT: Solver doesn't get the TIA (opportunity cost)                           │
+│  • Escrow expires → TIA refunded to user via IBC                                │
+│  • SOLVER TAKES THIS RISK → incentive to run reliable relayers                  │
+│                                                                                  │
+│  SCENARIO 3: Solver never attempts delivery                                     │
+│  ─────────────────────────────────────────────                                  │
+│  • Escrow expires after 15 minutes                                              │
+│  • User can trigger refund                                                       │
+│  • TIA sent back to Celestia via IBC                                            │
+│  • Solver potentially slashed (if bonded)                                       │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Escrow Contract Updates
+
+### New Fields for Cross-Chain Escrow
+
+```rust
+#[cw_serde]
+pub struct Escrow {
+    pub id: String,
+
+    /// Owner address - may be on a DIFFERENT chain
+    pub owner: String,
+
+    /// Chain where owner address exists
+    pub owner_chain_id: String,
+
+    /// IBC channel used for inbound transfer (for refunds)
+    pub source_channel: String,
+
+    /// Original denom on source chain (for refund routing)
+    pub source_denom: String,
+
+    pub amount: Uint128,
+    pub denom: String,  // This is the ibc/... denom on Hub
+    pub intent_id: String,
+    pub expires_at: u64,
+    pub status: EscrowStatus,
+}
+```
+
+### Lock via IBC Hooks
+
+```rust
+/// Called by IBC Hooks middleware when receiving funds
+#[cw_serde]
+pub enum ExecuteMsg {
+    /// Standard lock (for Hub-native users)
+    Lock {
+        escrow_id: String,
+        intent_id: String,
+        expires_at: u64,
+    },
+
+    /// Lock via IBC receive (for cross-chain users)
+    LockFromIbc {
+        intent_id: String,
+        expires_at: u64,
+        /// User's address on the source chain
+        user_source_address: String,
+        /// Source chain ID (e.g., "celestia")
+        source_chain_id: String,
+        /// Channel the funds came through (for refunds)
+        source_channel: String,
+    },
+
+    // ... existing messages
+}
+```
+
+### Refund via IBC
+
+```rust
+fn execute_refund(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    escrow_id: String,
+) -> Result<Response, ContractError> {
+    let escrow = ESCROWS.load(deps.storage, &escrow_id)?;
+
+    // Verify escrow is expired
+    if env.block.time.seconds() < escrow.expires_at {
+        return Err(ContractError::EscrowNotExpired { id: escrow_id });
+    }
+
+    // Check status
+    if !matches!(escrow.status, EscrowStatus::Locked) {
+        return Err(ContractError::InvalidStatus {});
+    }
+
+    // Determine refund method based on owner chain
+    let refund_msg = if escrow.owner_chain_id == "cosmoshub-4" {
+        // Local refund - simple bank send
+        BankMsg::Send {
+            to_address: escrow.owner.clone(),
+            amount: vec![Coin {
+                denom: escrow.denom.clone(),
+                amount: escrow.amount,
+            }],
+        }.into()
+    } else {
+        // Cross-chain refund - IBC transfer back to source
+        MsgTransfer {
+            source_port: "transfer".to_string(),
+            source_channel: escrow.source_channel.clone(),
+            token: Some(Coin {
+                denom: escrow.denom.clone(),
+                amount: escrow.amount,
+            }.into()),
+            sender: env.contract.address.to_string(),
+            receiver: escrow.owner.clone(),  // Address on source chain
+            timeout_height: None,
+            timeout_timestamp: env.block.time.plus_seconds(600).nanos(),
+            memo: "".to_string(),
+        }.into()
+    };
+
+    // Update status
+    ESCROWS.update(deps.storage, &escrow_id, |e| -> StdResult<_> {
+        let mut escrow = e.unwrap();
+        escrow.status = EscrowStatus::Refunding;
+        Ok(escrow)
+    })?;
+
+    Ok(Response::new()
+        .add_message(refund_msg)
+        .add_attribute("action", "refund")
+        .add_attribute("escrow_id", escrow_id)
+        .add_attribute("refund_to", escrow.owner)
+        .add_attribute("refund_chain", escrow.owner_chain_id))
+}
+```
+
+---
+
+## IBC Memo Format
+
+### Standard Transfer + Escrow Lock
+
+```json
+{
+  "wasm": {
+    "contract": "cosmos1escrowcontract...",
+    "msg": {
+      "lock_from_ibc": {
+        "intent_id": "int_abc123",
+        "expires_at": 1703520000,
+        "user_source_address": "celestia1user...",
+        "source_chain_id": "celestia",
+        "source_channel": "channel-0"
+      }
+    }
+  }
+}
+```
+
+### With Swap + Forward (TIA → USDC via Osmosis)
+
+For cases where the swap happens on an intermediate chain:
+
+```json
+{
+  "wasm": {
+    "contract": "cosmos1escrowcontract...",
+    "msg": {
+      "lock_from_ibc": {
+        "intent_id": "int_abc123",
+        "expires_at": 1703520000,
+        "user_source_address": "celestia1user...",
+        "source_chain_id": "celestia",
+        "source_channel": "channel-0"
+      }
+    }
+  }
+}
+```
+
+The swap is handled **after** escrow lock, during settlement phase, not during the initial transfer.
+
+---
+
+## Settlement Flow Decision Tree
+
+```
+Intent received from user on chain X
+    │
+    ├── Is X = cosmoshub-4?
+    │       │
+    │       ├── YES: Lock directly in escrow contract
+    │       │
+    │       └── NO: Does X have smart contracts?
+    │               │
+    │               ├── YES: Lock in escrow on X (future)
+    │               │
+    │               └── NO: Route to Hub escrow via IBC Hooks
+    │                         │
+    │                         └── Construct IBC transfer with wasm memo
+    │                             pointing to Hub escrow contract
+    │
+    ▼
+Escrow locked on Hub
+    │
+    ├── Solver commits output in Hub vault
+    │
+    ├── Settlement contract releases output via IBC
+    │   │
+    │   └── Routes to user's desired destination chain
+    │
+    └── On success: Release escrow to solver
+        On timeout: Refund escrow to user (via IBC if needed)
+```
+
+---
+
+## Chain Capability Registry
+
+To support this flow, we need to track chain capabilities:
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ChainCapabilities {
+    pub chain_id: String,
+
+    /// Does this chain support CosmWasm smart contracts?
+    pub has_cosmwasm: bool,
+
+    /// Address of escrow contract (if deployed on this chain)
+    pub escrow_contract: Option<String>,
+
+    /// IBC channels to the default escrow chain (Hub)
+    pub channel_to_hub: Option<String>,
+
+    /// Does this chain support IBC Hooks?
+    pub has_ibc_hooks: bool,
+}
+
+pub struct ChainRegistry {
+    chains: HashMap<String, ChainCapabilities>,
+}
+
+impl ChainRegistry {
+    pub fn new() -> Self {
+        let mut chains = HashMap::new();
+
+        // Cosmos Hub - default escrow chain
+        chains.insert("cosmoshub-4".to_string(), ChainCapabilities {
+            chain_id: "cosmoshub-4".to_string(),
+            has_cosmwasm: true,
+            escrow_contract: Some("cosmos1escrow...".to_string()),
+            channel_to_hub: None,  // Is the Hub
+            has_ibc_hooks: true,
+        });
+
+        // Celestia - no smart contracts
+        chains.insert("celestia".to_string(), ChainCapabilities {
+            chain_id: "celestia".to_string(),
+            has_cosmwasm: false,
+            escrow_contract: None,
+            channel_to_hub: Some("channel-0".to_string()),
+            has_ibc_hooks: false,
+        });
+
+        // Osmosis - has contracts
+        chains.insert("osmosis-1".to_string(), ChainCapabilities {
+            chain_id: "osmosis-1".to_string(),
+            has_cosmwasm: true,
+            escrow_contract: None,  // Using Hub for now
+            channel_to_hub: Some("channel-0".to_string()),
+            has_ibc_hooks: true,
+        });
+
+        // Noble - no CosmWasm but supports IBC
+        chains.insert("noble-1".to_string(), ChainCapabilities {
+            chain_id: "noble-1".to_string(),
+            has_cosmwasm: false,
+            escrow_contract: None,
+            channel_to_hub: Some("channel-4".to_string()),
+            has_ibc_hooks: false,
+        });
+
+        Self { chains }
+    }
+
+    /// Determine which chain should hold escrow for a given source chain
+    pub fn get_escrow_chain(&self, source_chain: &str) -> &str {
+        let source = self.chains.get(source_chain);
+
+        match source {
+            Some(caps) if caps.escrow_contract.is_some() => source_chain,
+            _ => "cosmoshub-4",  // Default to Hub
+        }
+    }
+}
+```
+
+---
+
+## Timeout and Failure Handling
+
+### Scenario 1: IBC Transfer to Hub Times Out
+
+```
+CELESTIA                           COSMOS HUB
+    │                                   │
+    │  MsgTransfer + wasm memo          │
+    │  ───────────────────────────────► │
+    │                                   │
+    │      ╳ TIMEOUT (chain down,       │
+    │        relayer issues, etc.)      │
+    │                                   │
+    │  ◄─────── MsgTimeout ──────────── │
+    │                                   │
+    │  Funds return to user on Celestia │
+    │  (IBC standard timeout refund)    │
+    │                                   │
+    │  USER CAN RETRY ✓                 │
+```
+
+### Scenario 2: Escrow Lock Fails (contract error)
+
+```
+CELESTIA                           COSMOS HUB
+    │                                   │
+    │  MsgTransfer + wasm memo          │
+    │  ───────────────────────────────► │
+    │                                   │
+    │                              IBC Hooks calls
+    │                              escrow.lock()
+    │                                   │
+    │                              ╳ CONTRACT ERROR
+    │                              (invalid params,
+    │                               escrow exists, etc.)
+    │                                   │
+    │                              IBC receive REVERTS
+    │                                   │
+    │  ◄─────── Error Ack ──────────── │
+    │                                   │
+    │  Funds return to user on Celestia │
+    │  (IBC atomic revert)              │
+    │                                   │
+    │  USER CAN RETRY ✓                 │
+```
+
+### Scenario 3: Solver Fails to Deliver
+
+```
+COSMOS HUB                              NOBLE
+    │                                      │
+    │  User escrow: LOCKED                 │
+    │  Solver vault: LOCKED                │
+    │                                      │
+    │  MsgTransfer (solver output)         │
+    │  ─────────────────────────────────►  │
+    │                                      │
+    │      ╳ TIMEOUT                       │
+    │                                      │
+    │  ◄─────── MsgTimeout ──────────────  │
+    │                                      │
+    │  Settlement contract detects timeout │
+    │  1. Unlock solver vault              │
+    │  2. Refund user escrow               │
+    │     - If user on Hub: bank send      │
+    │     - If user on Celestia: IBC back  │
+    │                                      │
+    │  BOTH PARTIES REFUNDED ✓             │
+```
+
+### Scenario 4: Refund IBC Fails
+
+```
+COSMOS HUB                              CELESTIA
+    │                                      │
+    │  Escrow expired, initiating refund   │
+    │                                      │
+    │  MsgTransfer (refund to user)        │
+    │  ─────────────────────────────────►  │
+    │                                      │
+    │      ╳ TIMEOUT                       │
+    │                                      │
+    │  ◄─────── MsgTimeout ──────────────  │
+    │                                      │
+    │  Funds return to escrow contract     │
+    │  Escrow status: RefundFailed         │
+    │                                      │
+    │  User or admin can retry refund      │
+    │  FUNDS SAFE IN ESCROW ✓              │
+```
+
+---
+
+## Security Considerations
+
+### 1. IBC Hooks Authentication
+
+The escrow contract must verify that `LockFromIbc` is only called by the IBC Hooks middleware:
+
+```rust
+fn execute_lock_from_ibc(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: LockFromIbcMsg,
+) -> Result<Response, ContractError> {
+    // Verify caller is the IBC transfer module
+    // IBC Hooks calls the contract with the transfer module as sender
+    let config = CONFIG.load(deps.storage)?;
+
+    // The actual sender in IBC Hooks is the derived address
+    // We verify the funds came through IBC by checking the denom
+    if !info.funds.iter().any(|c| c.denom.starts_with("ibc/")) {
+        return Err(ContractError::NotIbcFunds {});
+    }
+
+    // Additional verification: check that exactly one IBC coin was sent
+    let ibc_funds: Vec<_> = info.funds.iter()
+        .filter(|c| c.denom.starts_with("ibc/"))
+        .collect();
+
+    if ibc_funds.len() != 1 {
+        return Err(ContractError::InvalidFunds {
+            expected: "exactly one IBC denom".to_string(),
+            got: format!("{} IBC denoms", ibc_funds.len()),
+        });
+    }
+
+    // Proceed with escrow creation
+    // ...
+}
+```
+
+### 2. Replay Protection
+
+Each intent has a unique ID, and each escrow is tied to that intent:
+
+```rust
+// Prevent duplicate escrows for same intent
+if ESCROWS_BY_INTENT.has(deps.storage, &msg.intent_id) {
+    return Err(ContractError::IntentAlreadyEscrowed {
+        intent_id: msg.intent_id
+    });
+}
+```
+
+### 3. Timeout Ordering
+
+Escrow timeout must be longer than IBC timeout + safety buffer:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                           TIMEOUT ORDERING                                       │
+│                                                                                  │
+│  T+0       User initiates transfer from Celestia                                │
+│  T+6s      IBC receives on Hub, escrow locks                                    │
+│  T+10min   IBC timeout for output delivery (if not delivered)                   │
+│  T+15min   Escrow timeout (5 min buffer after IBC timeout)                      │
+│                                                                                  │
+│  This ensures:                                                                   │
+│  - Solver has time to detect IBC timeout                                        │
+│  - Settlement contract can unwind before escrow expires                         │
+│  - No race conditions between refund and release                                │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Gas Costs
+
+| Operation | Estimated Gas | Estimated Cost |
+|-----------|---------------|----------------|
+| IBC Transfer (Celestia → Hub) | 100,000 | ~$0.01 TIA |
+| Escrow Lock (via Hooks) | 150,000 | ~$0.02 ATOM |
+| Solver Vault Commit | 120,000 | ~$0.02 ATOM |
+| IBC Transfer (Hub → Noble) | 100,000 | ~$0.02 ATOM |
+| Escrow Release | 80,000 | ~$0.01 ATOM |
+| **Total** | ~550,000 | **~$0.08** |
+
+---
+
+## Implementation Checklist
+
+### Smart Contracts
+
+- [ ] Update `contracts/escrow` to support `LockFromIbc` message
+- [ ] Add `owner_chain_id` and `source_channel` fields to Escrow struct
+- [ ] Implement IBC refund logic for cross-chain escrows
+- [ ] Add escrow-by-intent index for duplicate prevention
+
+### Settlement Crate
+
+- [ ] Add `ChainCapabilities` registry
+- [ ] Update `SettlementManager` to route to Hub escrow for non-wasm chains
+- [ ] Implement IBC memo construction for wasm hooks
+- [ ] Add cross-chain refund handling
+
+### Solver Integration
+
+- [ ] Update solvers to watch for escrow events on Hub
+- [ ] Handle ibc/* denoms in inventory management
+- [ ] Add TIA/USDC pair support
+
+### Configuration
+
+- [ ] Add Celestia chain config with IBC channel mappings
+- [ ] Configure TIA denom traces
+- [ ] Set up channel registry for Celestia ↔ Hub
+
+---
+
+## Summary
+
+This specification enables users on chains without smart contracts (like Celestia) to participate in the intent-based swap system through:
+
+### Core Design
+
+1. **Hub as Neutral Adjudicator** - Cosmos Hub holds escrow and verifies delivery
+2. **IBC Hooks for atomic lock-on-receive** - User's TIA locked atomically on Hub
+3. **Solver takes relay risk** - Solvers responsible for timely delivery
+4. **Cross-chain refunds via IBC** - Timeout protection works across chains
+
+### Trust Model
+
+| Party | Trust Required | Protection |
+|-------|----------------|------------|
+| **User** | None | TIA locked in Hub escrow, refunded if delivery fails |
+| **Solver** | Takes relay risk | Must ensure USDC delivery; loses opportunity if timeout |
+| **Hub** | Smart contract correctness | Audited contracts, on-chain verification |
+
+### Key Properties
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         SYSTEM PROPERTIES                                        │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  ✓ TRUSTLESS FOR USER                                                           │
+│    User's funds protected by Hub escrow contract                                │
+│    No trust required in solver - Hub adjudicates                                │
+│                                                                                  │
+│  ✓ INCENTIVE-ALIGNED FOR SOLVER                                                 │
+│    Solver takes relay risk → runs reliable relayers                             │
+│    Faster delivery → shorter exposure → more auction wins                       │
+│                                                                                  │
+│  ✓ NO SMART CONTRACTS ON CELESTIA                                               │
+│    Works with pure IBC transfer capability                                       │
+│    Hub escrow handles the complexity                                            │
+│                                                                                  │
+│  ✓ SINGLE USER SIGNATURE                                                        │
+│    User signs one IBC transfer on Celestia                                      │
+│    Everything else happens automatically                                         │
+│                                                                                  │
+│  ✓ ~13 SECOND END-TO-END                                                        │
+│    Fast execution via solver relayers                                           │
+│    Comparable to centralized exchange experience                                │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### User Experience
+
+The user experience is simple: **sign one transaction on Celestia, receive USDC on Noble**.
+
+The complexity of Hub escrow, solver coordination, and IBC relaying is handled entirely by the system.


### PR DESCRIPTION
This adds support for swapping TIA (Celestia) to USDC in the intent system, handling the unique challenge that Celestia has no smart contract support.

Key design decisions:
- Hub serves as neutral adjudicator with escrow contract
- User's TIA sent to Hub via IBC Hooks, locked atomically
- Solver delivers USDC to user, takes relay risk
- Hub verifies delivery via IBC ack, releases TIA to solver

Changes:
- Add TIA_USDC_SWAP_SPECIFICATION.md with full architecture
- Add TIA token and Celestia chain to demo UI types
- Add tia_usdc_swap demo scenario to simulator API
- Add Celestia Bridge Solver to mock solvers
- Add TIA price feed to oracle
- Feature TIA→USDC flow prominently in DemoScenarios component